### PR TITLE
fix: Update subscription validation to work with SSO

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -31,7 +31,18 @@ where
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct BillingInfo {
-    pub next_billing_date: String,
+    pub subscription: SubscriptionInfo,
+    pub trial: TrialInfo,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub(crate) struct SubscriptionInfo {
+    pub cancellation_date: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+pub(crate) struct TrialInfo {
+    pub trial_expiration_date: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This PR adds support for validating the subscription by using `/api/v1/` instead of `/api/v1/payments/next_billing_date/`, since SSO users don't always have access to managing the payment for their account. `/api/v1/`  seems to provide an overview of the currently logged in user which has both a `subscription` field and a `trail` field detailing when those payments will expire.

I have validated this works with both an SSO account and a trail membership. I believe this should close #1