### PR TITLE
Fix SubscriptionExpired error when the subscription is still valid

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -91,6 +91,12 @@ impl OreillyClient<Unauthenticated> {
 
         let billing = response.json::<BillingInfo>().await?;
 
+        // Skip the entire expiration check if cancellation_date is None
+        if billing.subscription.cancellation_date.is_none() {
+          info!("Subscription is still valid, continuing to download the book...");
+          return Ok(());
+        }
+
         trace!("Billing details: {:#?}", &billing);
         let expiration = if let Some(sub_exp) = billing.subscription.cancellation_date {
             let dt = NaiveDate::parse_from_str(&sub_exp, "%Y-%m-%d")


### PR DESCRIPTION
This PR fixes the `SubscriptionExpired` error while the current subscription is still active. Turn out that when the subscription is still active, the response doesn't have a `cancellation_date` value. So I skip the entire expiration check if `cancellation_date` is empty.

Active subscription response example:
```
BillingInfo {
    subscription: SubscriptionInfo {
        cancellation_date: None,
    },
    trial: TrialInfo {
        trial_expiration_date: Some(
            "2019-11-17T04:02:39.550054Z",
        ),
    },
}
```

Related discussion: https://github.com/hurlenko/orly/pull/5#issuecomment-1636152754